### PR TITLE
Simplify difficulty buttons - remove size and mine count

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,9 +17,9 @@
       </select>
     </div>
     <div id="controls">
-      <button id="beginner" class="level-btn active">Beginner (9×9, 10 mines)</button>
-      <button id="master" class="level-btn">Master (16×16, 40 mines)</button>
-      <button id="expert" class="level-btn">Expert (30×16, 99 mines)</button>
+      <button id="beginner" class="level-btn active" title="9×9 grid, 10 mines">Beginner</button>
+      <button id="master" class="level-btn" title="16×16 grid, 40 mines">Master</button>
+      <button id="expert" class="level-btn" title="30×16 grid, 99 mines">Expert</button>
     </div>
     <div id="status">
       <span id="mine-count">Mines: 10</span>

--- a/src/style.css
+++ b/src/style.css
@@ -156,6 +156,7 @@ h1 {
 
 .level-btn {
   background-color: var(--button-bg) !important;
+  width: 90px;
 }
 
 .level-btn.active {


### PR DESCRIPTION
## Summary

This PR addresses issue #35 by simplifying the difficulty selection buttons.

## Changes

- Simplified button labels: removed grid size and mine count from button text
  - \Beginner (9×9, 10 mines)\ → \Beginner\
  - \Master (16×16, 40 mines)\ → \Master\
  - \Expert (30×16, 99 mines)\ → \Expert\
- Added tooltips on hover showing grid size and mine count
- Set fixed button width (90px) so all buttons are the same size

## Acceptance Criteria

- [x] Difficulty buttons show only the difficulty name
- [x] Add tooltip with size/mine details on hover
- [x] Buttons remain visually balanced and properly sized

## Testing

1. Start the dev server: \
pm run dev\
2. Verify buttons show simplified labels
3. Hover over buttons to see tooltips with details

Closes #35