### PR TITLE
Add adjustable cell size for accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,14 @@
           <option value="classic">Classic Win98</option>
         </select>
       </div>
+      <div class="settings-section">
+        <label>Cell Size:</label>
+        <div class="size-buttons">
+          <button class="size-btn active" data-size="small" title="Small">A</button>
+          <button class="size-btn" data-size="medium" title="Medium">A</button>
+          <button class="size-btn" data-size="large" title="Large">A</button>
+        </div>
+      </div>
     </div>
   </div>
   

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,16 +1,52 @@
+export type CellSize = 'small' | 'medium' | 'large';
+
+const CELL_SIZE_STORAGE_KEY = 'minesweeper-cell-size';
+
 export class SettingsModal {
   private modal: HTMLElement;
   private settingsBtn: HTMLElement;
   private closeBtn: HTMLElement;
   private backdrop: HTMLElement;
+  private sizeButtons: NodeListOf<HTMLButtonElement>;
 
   constructor() {
     this.modal = document.getElementById('settings-modal')!;
     this.settingsBtn = document.getElementById('settings-btn')!;
     this.closeBtn = document.getElementById('settings-close')!;
     this.backdrop = this.modal.querySelector('.modal-backdrop')!;
+    this.sizeButtons = this.modal.querySelectorAll('.size-btn');
 
+    this.initCellSize();
     this.setupEventListeners();
+  }
+
+  private initCellSize(): void {
+    const savedSize = this.getSavedCellSize() || 'small';
+    this.applyCellSize(savedSize);
+    this.updateSizeButtons(savedSize);
+  }
+
+  private getSavedCellSize(): CellSize | null {
+    const saved = localStorage.getItem(CELL_SIZE_STORAGE_KEY);
+    if (saved && ['small', 'medium', 'large'].includes(saved)) {
+      return saved as CellSize;
+    }
+    return null;
+  }
+
+  private applyCellSize(size: CellSize): void {
+    document.documentElement.setAttribute('data-cell-size', size);
+    localStorage.setItem(CELL_SIZE_STORAGE_KEY, size);
+  }
+
+  private updateSizeButtons(activeSize: CellSize): void {
+    this.sizeButtons.forEach(btn => {
+      if (btn.dataset.size === activeSize) {
+        btn.classList.add('active');
+      } else {
+        btn.classList.remove('active');
+      }
+    });
   }
 
   private setupEventListeners(): void {
@@ -26,6 +62,15 @@ export class SettingsModal {
       if (e.key === 'Escape' && !this.modal.classList.contains('hidden')) {
         this.close();
       }
+    });
+
+    // Cell size buttons
+    this.sizeButtons.forEach(btn => {
+      btn.addEventListener('click', () => {
+        const size = btn.dataset.size as CellSize;
+        this.applyCellSize(size);
+        this.updateSizeButtons(size);
+      });
     });
   }
 

--- a/src/style.css
+++ b/src/style.css
@@ -294,8 +294,8 @@ h1 {
 }
 
 .cell {
-  width: 30px;
-  height: 30px;
+  width: var(--cell-size, 30px);
+  height: var(--cell-size, 30px);
   border: 2px outset var(--cell-border-out);
   background-color: var(--cell-bg);
   display: flex;
@@ -303,9 +303,64 @@ h1 {
   justify-content: center;
   font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
   font-weight: bold;
-  font-size: 14px;
+  font-size: var(--cell-font-size, 14px);
   cursor: pointer;
   user-select: none;
+}
+
+/* Cell size variants */
+[data-cell-size="small"] {
+  --cell-size: 30px;
+  --cell-font-size: 14px;
+}
+
+[data-cell-size="medium"] {
+  --cell-size: 40px;
+  --cell-font-size: 18px;
+}
+
+[data-cell-size="large"] {
+  --cell-size: 50px;
+  --cell-font-size: 24px;
+}
+
+/* Size selector buttons */
+.size-buttons {
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+}
+
+.size-btn {
+  border: none;
+  background: none;
+  color: var(--text-color);
+  cursor: pointer;
+  font-family: serif;
+  font-weight: bold;
+  padding: 2px 4px;
+  opacity: 0.5;
+}
+
+.size-btn[data-size="small"] {
+  font-size: 20px;
+}
+
+.size-btn[data-size="medium"] {
+  font-size: 28px;
+}
+
+.size-btn[data-size="large"] {
+  font-size: 36px;
+}
+
+.size-btn.active {
+  opacity: 1;
+  text-decoration: underline;
+}
+
+.size-btn:hover:not(.active) {
+  opacity: 0.8;
 }
 
 .cell:hover:not(.revealed):not(.flagged) {


### PR DESCRIPTION
## Summary

This PR addresses issue #4 by adding adjustable cell sizes to improve accessibility and accommodate different screen sizes and user preferences.

## Changes

- Added cell size selector in settings modal with three options: Small (30px), Medium (40px), Large (50px)
- Uses text-style 'A' buttons at different font sizes (20px, 28px, 36px) for intuitive size selection
- Cell size preference is persisted in localStorage
- CSS variables control cell and font sizes for easy theming

## Acceptance Criteria

- [x] Three cell size options available
- [x] Size selector in settings modal with A buttons
- [x] Selection persisted across sessions
- [x] Grid adjusts properly to different cell sizes
- [x] Numbers remain centered and readable at all sizes

## Testing

1. Start the dev server: \
pm run dev\
2. Click the settings (gear) button
3. Try each cell size option (A buttons)
4. Verify grid updates and preference persists after refresh

Closes #4