### PR TITLE
Add CODEOWNERS for automatic PR review requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS - Automatically request reviews from code owners
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything in the repo
+* @m-kinchin


### PR DESCRIPTION
## Summary

Adds a CODEOWNERS file to automatically request reviews from @m-kinchin on all PRs.

## Changes

- Created \.github/CODEOWNERS\ with default owner for all files

## What this does

- Automatically requests review from @m-kinchin when PRs are opened
- Works with branch protection rules that require CODEOWNERS approval
- Provides clear ownership documentation

## Reference

- [GitHub CODEOWNERS documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)