### PR TITLE
Display timer in minutes:seconds format

### DIFF
--- a/src/timeFormat.test.ts
+++ b/src/timeFormat.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { formatTime } from './timeFormat';
+
+describe('formatTime', () => {
+  it('should format 0 seconds as 0:00', () => {
+    expect(formatTime(0)).toBe('0:00');
+  });
+
+  it('should format 5 seconds as 0:05 (zero-padded seconds)', () => {
+    expect(formatTime(5)).toBe('0:05');
+  });
+
+  it('should format 65 seconds as 1:05', () => {
+    expect(formatTime(65)).toBe('1:05');
+  });
+
+  it('should format 125 seconds as 2:05', () => {
+    expect(formatTime(125)).toBe('2:05');
+  });
+
+  it('should format 90 seconds as 1:30', () => {
+    expect(formatTime(90)).toBe('1:30');
+  });
+
+  it('should format 765 seconds as 12:45', () => {
+    expect(formatTime(765)).toBe('12:45');
+  });
+
+  it('should format 3599 seconds as 59:59', () => {
+    expect(formatTime(3599)).toBe('59:59');
+  });
+
+  it('should format 3600 seconds as 60:00 (past 59:59)', () => {
+    expect(formatTime(3600)).toBe('60:00');
+  });
+
+  it('should format 7200 seconds as 120:00 (two hours)', () => {
+    expect(formatTime(7200)).toBe('120:00');
+  });
+
+  it('should format 10 seconds as 0:10', () => {
+    expect(formatTime(10)).toBe('0:10');
+  });
+
+  it('should format 59 seconds as 0:59', () => {
+    expect(formatTime(59)).toBe('0:59');
+  });
+
+  it('should format 60 seconds as 1:00', () => {
+    expect(formatTime(60)).toBe('1:00');
+  });
+});

--- a/src/timeFormat.ts
+++ b/src/timeFormat.ts
@@ -1,0 +1,10 @@
+/**
+ * Formats elapsed time in seconds to M:SS or MM:SS format.
+ * @param seconds Total elapsed time in seconds
+ * @returns Formatted time string (e.g., "0:05", "1:30", "12:45", "60:00")
+ */
+export function formatTime(seconds: number): string {
+  const minutes = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${minutes}:${secs.toString().padStart(2, '0')}`;
+}

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -3,6 +3,7 @@ import { Cell, GameConfig } from './types';
 import { getAnimationManager, AnimationManager } from './animations';
 import { GamePersistence } from './persistence';
 import { validateCustomSettings, getMaxMines, CustomSettings } from './validation';
+import { formatTime } from './timeFormat';
 
 interface DifficultyLevel {
   name: string;
@@ -333,7 +334,7 @@ export class GameUI {
   }
 
   private updateTimerDisplay(): void {
-    this.timerElement.textContent = `Time: ${this.elapsedTime}`;
+    this.timerElement.textContent = `Time: ${formatTime(this.elapsedTime)}`;
   }
 
   private render(): void {


### PR DESCRIPTION
## Summary
Formats the timer display from raw seconds to M:SS format for better readability.

## Changes
- Add \ormatTime\ utility function in \src/timeFormat.ts\
- Update timer display in \src/ui.ts\ to use formatted time
- Add 12 unit tests for time formatting

## Examples
| Before | After |
|--------|-------|
| Time: 5 | Time: 0:05 |
| Time: 65 | Time: 1:05 |
| Time: 125 | Time: 2:05 |
| Time: 3600 | Time: 60:00 |

## Testing
- All 94 tests pass (12 new)
- Manually verified timer display in browser

Closes #33