### PR TITLE
feat: First click always opens a larger area

### DIFF
--- a/src/game.test.ts
+++ b/src/game.test.ts
@@ -58,6 +58,32 @@ describe('MinesweeperGame', () => {
       }
     });
 
+    it('first click area (3x3) has zero adjacent mines for guaranteed opening', () => {
+      const game = new MinesweeperGame({ rows: 9, cols: 9, mines: 10 });
+      game.reveal(4, 4); // First click at center
+
+      // The 3x3 area around first click should all have 0 adjacent mines
+      for (let dr = -1; dr <= 1; dr++) {
+        for (let dc = -1; dc <= 1; dc++) {
+          const cell = game.getCell(4 + dr, 4 + dc);
+          expect(cell?.adjacentMines).toBe(0);
+        }
+      }
+    });
+
+    it('first click opens at least 3x3 area automatically', () => {
+      const game = new MinesweeperGame({ rows: 9, cols: 9, mines: 10 });
+      game.reveal(4, 4); // First click at center
+
+      // All cells in 3x3 area should be revealed due to cascade
+      for (let dr = -1; dr <= 1; dr++) {
+        for (let dc = -1; dc <= 1; dc++) {
+          const cell = game.getCell(4 + dr, 4 + dc);
+          expect(cell?.isRevealed).toBe(true);
+        }
+      }
+    });
+
     it('calculates adjacent mine counts correctly', () => {
       const game = new MinesweeperGame({ rows: 9, cols: 9, mines: 10 });
       game.reveal(0, 0); // First click
@@ -678,12 +704,12 @@ describe('MinesweeperGame', () => {
     });
 
     it('cannot transition from lost to won', () => {
-      const game = new MinesweeperGame({ rows: 5, cols: 5, mines: 3 });
-      game.reveal(2, 2);
+      const game = new MinesweeperGame({ rows: 9, cols: 9, mines: 10 });
+      game.reveal(4, 4);
 
       // Lose by clicking a mine
-      for (let row = 0; row < 5; row++) {
-        for (let col = 0; col < 5; col++) {
+      for (let row = 0; row < 9; row++) {
+        for (let col = 0; col < 9; col++) {
           if (game.getCell(row, col)?.isMine) {
             game.reveal(row, col);
             break;
@@ -695,8 +721,8 @@ describe('MinesweeperGame', () => {
       expect(game.gameState).toBe('lost');
 
       // Try to flag all remaining mines
-      for (let row = 0; row < 5; row++) {
-        for (let col = 0; col < 5; col++) {
+      for (let row = 0; row < 9; row++) {
+        for (let col = 0; col < 9; col++) {
           if (game.getCell(row, col)?.isMine) {
             game.toggleFlag(row, col);
           }
@@ -821,13 +847,13 @@ describe('MinesweeperGame', () => {
     });
 
     it('preserves flag state after serialize/deserialize', () => {
-      const game = new MinesweeperGame({ rows: 5, cols: 5, mines: 3 });
-      game.reveal(2, 2);
+      const game = new MinesweeperGame({ rows: 9, cols: 9, mines: 10 });
+      game.reveal(4, 4);
       
       // Find two unrevealed cells to flag (cascade may have revealed some)
       const unrevealedCells: Array<{row: number, col: number}> = [];
-      for (let row = 0; row < 5 && unrevealedCells.length < 2; row++) {
-        for (let col = 0; col < 5 && unrevealedCells.length < 2; col++) {
+      for (let row = 0; row < 9 && unrevealedCells.length < 2; row++) {
+        for (let col = 0; col < 9 && unrevealedCells.length < 2; col++) {
           const cell = game.getCell(row, col);
           if (cell && !cell.isRevealed) {
             unrevealedCells.push({row, col});
@@ -849,8 +875,8 @@ describe('MinesweeperGame', () => {
     });
 
     it('can continue playing after restore', () => {
-      const game = new MinesweeperGame({ rows: 5, cols: 5, mines: 3 });
-      game.reveal(2, 2);
+      const game = new MinesweeperGame({ rows: 9, cols: 9, mines: 10 });
+      game.reveal(4, 4);
 
       const serialized = game.serialize();
       const restored = MinesweeperGame.deserialize(serialized);
@@ -859,8 +885,8 @@ describe('MinesweeperGame', () => {
       expect(restored.gameState).toBe('playing');
       
       // Find an unrevealed non-mine cell and reveal it
-      for (let row = 0; row < 5; row++) {
-        for (let col = 0; col < 5; col++) {
+      for (let row = 0; row < 9; row++) {
+        for (let col = 0; col < 9; col++) {
           const cell = restored.getCell(row, col);
           if (cell && !cell.isRevealed && !cell.isMine && !cell.isFlagged) {
             const result = restored.reveal(row, col);

--- a/src/game.ts
+++ b/src/game.ts
@@ -59,14 +59,17 @@ export class MinesweeperGame {
 
   private placeMines(excludeRow: number, excludeCol: number): void {
     let minesPlaced = 0;
-    const maxMines = Math.min(this.config.mines, this.config.rows * this.config.cols - 9);
+    // Exclusion zone is 5x5 (25 cells) to ensure 3x3 opening area has no adjacent mines
+    const exclusionSize = 25;
+    const maxMines = Math.min(this.config.mines, this.config.rows * this.config.cols - exclusionSize);
 
     while (minesPlaced < maxMines) {
       const row = Math.floor(Math.random() * this.config.rows);
       const col = Math.floor(Math.random() * this.config.cols);
 
-      // Don't place mine on first click or adjacent cells
-      if (Math.abs(row - excludeRow) <= 1 && Math.abs(col - excludeCol) <= 1) {
+      // Don't place mine within 5x5 area around first click (distance <= 2)
+      // This ensures the 3x3 center area will have zero adjacent mines
+      if (Math.abs(row - excludeRow) <= 2 && Math.abs(col - excludeCol) <= 2) {
         continue;
       }
 


### PR DESCRIPTION
First click now guarantees opening at least a 3x3 area of zeros. The mine exclusion zone is expanded from 3x3 to 5x5 around the first click, ensuring the center 3x3 area has no adjacent mines and triggers cascade reveal. Closes #15